### PR TITLE
CMake fixes related to SNLS used as submodule

### DIFF
--- a/cmake/CMakeBasics.cmake
+++ b/cmake/CMakeBasics.cmake
@@ -7,8 +7,8 @@ set(SNLS_VERSION_MAJOR 0)
 set(SNLS_VERSION_MINOR 3)
 set(SNLS_VERSION_PATCH \"0\")
 
-set(HEADER_INCLUDE_DIR
-    ${PROJECT_BINARY_DIR}/include
+set(SNLS_HEADER_INCLUDE_DIR
+    ${PROJECT_BINARY_DIR}/include/snls
     CACHE PATH
     "Directory where all generated headers will go in the build tree")
 
@@ -38,7 +38,7 @@ if(CMAKE_BUILD_TYPE MATCHES DEBUG)
 endif()
 
 configure_file( src/SNLS_config.h.in
-                ${HEADER_INCLUDE_DIR}/SNLS_config.h )
+                ${SNLS_HEADER_INCLUDE_DIR}/SNLS_config.h )
 
 ################################
 # Third party library setup

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SNLS_HEADERS
-    ${HEADER_INCLUDE_DIR}/SNLS_config.h
+    ${SNLS_HEADER_INCLUDE_DIR}/SNLS_config.h
     SNLS_base.h
     SNLS_cuda_portability.h
     SNLS_port.h
@@ -47,13 +47,13 @@ blt_add_library(NAME        snls
 # Install files
 #------------------------------------------------------------------------------
 
-install(FILES ${SNLS_HEADERS} DESTINATION include/)
+install(FILES ${SNLS_HEADERS} DESTINATION include/snls/)
 
 target_include_directories(
   snls
   PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+  $<BUILD_INTERFACE:${SNLS_HEADER_INCLUDE_DIR}>
   $<INSTALL_INTERFACE:include>)
 
 configure_file(
@@ -65,12 +65,12 @@ install(
   DESTINATION share/snls/cmake/)
 
 install(
-  FILES ${PROJECT_BINARY_DIR}/include/SNLS_config.h
-  DESTINATION include)
+  FILES ${SNLS_HEADER_INCLUDE_DIR}/SNLS_config.h
+  DESTINATION include/snls/)
 
 install(
   FILES ${SNLS_HEADERS}
-  DESTINATION include)
+  DESTINATION include/snls/)
 
 install(
   TARGETS snls

--- a/src/SNLS-config.cmake.in
+++ b/src/SNLS-config.cmake.in
@@ -30,7 +30,7 @@
 #----------------------------------------------------------------------------
 
 set (SNLS_INSTALL_PREFIX @CMAKE_INSTALL_PREFIX@)
-set (SNLS_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include)
+set (SNLS_INCLUDE_DIRS @CMAKE_INSTALL_PREFIX@/include/snls)
 set (SNLS_LIB_DIR @CMAKE_INSTALL_PREFIX@/lib)
 set (SNLS_CMAKE_DIR @CMAKE_INSTALL_PREFIX@/share/snls/cmake)
 


### PR DESCRIPTION
Several of the changes are motivated by trials to introduce v0.3.0 into ExaCMech. I'll have a companion PR within ExaCMech to go along with this one. (link here)

The changes are relatively small and should be easy to review.

Once these are changes are in I'll push a v0.3.0 tag up, and update the release branch.