### PR TITLE
Minor changes to various class behaviors

### DIFF
--- a/src/SNLS_HybrdTrDLDenseG.h
+++ b/src/SNLS_HybrdTrDLDenseG.h
@@ -138,7 +138,7 @@ class SNLSHybrdTrDLDenseG
     SNLSStatus_t solve() {
     
         if ( !m_complete) {
-        SNLS_FAIL("solve", "Setup not called beforehand!") ;
+            SNLS_FAIL("solve", "Setup not called beforehand!") ;
         }
 
         double residual[m_nDim];
@@ -303,7 +303,7 @@ class SNLSHybrdTrDLDenseG
                 // onto the other libraries / application codes using SNLS.
                 const bool success = this->computeNewtonStep( Jacobian, qtf, nrStep);
                 if (!success) {
-                    m_status = algFailure;
+                    m_status = SNLSStatus_t::linearSolveFailure;
                     return m_status;
                 }
             }
@@ -432,7 +432,7 @@ class SNLSHybrdTrDLDenseG
                // On the GPU, the fail just prints out and  doesn't abort anything so
                // we return this signal notifying us of the failure which can then be passed
                // onto the other libraries / application codes using SNLS.
-                SNLS_FAIL(__func__, "Diagonal term in R matrix was too small");
+                SNLS_WARN(__func__, "Diagonal term in R matrix was too small");
                 return false;
             }
             double sum = 0.0;

--- a/src/SNLS_TrDLDenseG.h
+++ b/src/SNLS_TrDLDenseG.h
@@ -186,7 +186,11 @@ class SNLSTrDlDenseG
                   snls::linalg::matVecMult<_nDim, _nDim>(Jacobian, grad, ntemp);
                   Jg_2 = snls::linalg::dotProd<_nDim>(ntemp, ntemp);
                }
-               this->computeNewtonStep( Jacobian, residual, nrStep );
+               const bool sol_stat = this->computeNewtonStep( Jacobian, residual, nrStep );
+               if (!sol_stat) {
+                  _status = SNLSStatus_t::linearSolveFailure;
+                  break;
+               }
 
             }
             //
@@ -281,7 +285,7 @@ class SNLSTrDlDenseG
       
    private :
    
-      __snls_hdev__ inline void  computeNewtonStep (double* const       J,
+      __snls_hdev__ inline bool  computeNewtonStep (double* const       J,
                                                     const double* const r,
                                                     double* const       newton  ) {
          
@@ -304,7 +308,10 @@ class SNLSTrDlDenseG
          int ipiv[_nDim] ;
          DGETRF(&_nDim, &_nDim, J, &_nDim, ipiv, &info) ;
 
-         if ( info != 0 ) { SNLS_FAIL(__func__, "info non-zero from dgetrf"); }
+         if ( info != 0 ) {
+            SNLS_WARN(__func__, "info non-zero from dgetrf");
+            return false;
+         }
 
          // std::copy( r, r + _nDim, newton );
          for (int iX = 0; iX < _nDim; ++iX) {
@@ -314,7 +321,10 @@ class SNLSTrDlDenseG
          int nRHS=1; info=0;
          DGETRS(&trans, &_nDim, &nRHS, J, &_nDim, ipiv, newton, &_nDim, &info);
 
-         if ( info != 0 ) { SNLS_FAIL(__func__, "info non-zero from lapack::dgetrs()") ; }
+         if ( info != 0 ) {
+            SNLS_WARN(__func__, "info non-zero from lapack::dgetrs()");
+            return false;
+         }
 
 #else
 // HAVE_LAPACK && SNLS_USE_LAPACK && defined(__cuda_host_only__)
@@ -324,7 +334,8 @@ class SNLSTrDlDenseG
 
             int   err = SNLS_LUP_Solve<n>(J, newton, r);
             if (err<0) {
-               SNLS_FAIL(__func__," fail return from LUP_Solve()") ;
+               SNLS_WARN(__func__," fail return from LUP_Solve()");
+               return false;
             }
             //
             for (int i=0; (i<n); ++i) { newton[i] = -newton[i]; }
@@ -332,6 +343,7 @@ class SNLSTrDlDenseG
          }
 #endif
 // HAVE_LAPACK && SNLS_USE_LAPACK && defined(__cuda_host_only__)
+         return true;
       }
       
       __snls_hdev__ inline void  reject(const double* const delX ) {

--- a/src/SNLS_base.h
+++ b/src/SNLS_base.h
@@ -24,6 +24,7 @@ typedef enum {
    slowConvergence    = -50,
    algFailure         = -100,
    bracketFailure     = -101,
+   linearSolveFailure = -110,
    unset              = -200
 } SNLSStatus_t ;
 

--- a/src/SNLS_device_forall.h
+++ b/src/SNLS_device_forall.h
@@ -105,13 +105,7 @@ namespace snls {
             }
          }
 
-         ~Device() {
-#ifdef __CUDACC__
-            Get()._es = ExecutionStrategy::CUDA;
-#else
-            Get()._es = ExecutionStrategy::CPU;
-#endif
-         }
+         ~Device() {}
    };
 
    /// The forall kernel body wrapper. It should be noted that one

--- a/src/SNLS_memory_manager.cxx
+++ b/src/SNLS_memory_manager.cxx
@@ -37,10 +37,8 @@ namespace snls {
       _device_allocator = _rm.makeAllocator<umpire::strategy::QuickPool>
 	                      ("MSLib_DEVICE_pool", _rm.getAllocator("DEVICE"),
                           initial_size);
-      es = chai::ExecutionSpace::GPU;
-#else
-      es = chai::ExecutionSpace::CPU;
 #endif
+      es = snls::Device::GetCHAIES();
    }
   
    /** Changes the internal host allocator to be one that

--- a/src/SNLS_memory_manager.h
+++ b/src/SNLS_memory_manager.h
@@ -15,6 +15,7 @@
 #include <umpire/Allocator.hpp>
 #include <umpire/ResourceManager.hpp>
 #include <umpire/strategy/QuickPool.hpp>
+#include <chai/config.hpp>
 #include <chai/ManagedArray.hpp>
 
 namespace snls {
@@ -90,6 +91,7 @@ namespace snls {
          inline
          chai::ManagedArray<T>* allocPManagedArray(std::size_t size=0)
          {
+            es = snls::Device::GetCHAIES();
             auto array = new chai::ManagedArray<T>(size, 
             std::initializer_list<chai::ExecutionSpace>{chai::CPU
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)


### PR DESCRIPTION
[Small changes to how the device and memory manager class work](https://github.com/LLNL/SNLS/commit/d3de9a5c6a09a594b8e0e1e13065dea68355b9ed)

In some more interesting test cases of the device and memory manager classes, I found that the device/memory manager classes didn't behave how I'd expect.
These small changes make sure things behave in an expected ways. For example, if a device object is dropped / deconstructed the internal singleton execution strategy would be reset. We don't want this as it would affect how later calls might behave.
Next, the memory manager would not set the initial execution space to be something consistent with what the device object is using. This rectifies that difference. Additionally, it fixes a small bug in the pointer version of the chai managed array function where the current execution space isn't used in the creation of the object.

[Fix how failures in linear solve are handled by nl solvers](https://github.com/LLNL/SNLS/commit/4a2fcaf00960b172b4cd308bc4e6e2343dcca54e)

In our nonlinear solvers, we would often SNLS_FAIL out if our linear solve for the newton step failed. This behavior is unwanted in a number of situations. For example on GPU runs, we would only print an error and continue on happily without external codes being aware an issue has occurred. In implicit FEM codes, we can encounter these sorts of issues from a large time step. Rather than having a code crash because it didn't catch the exception, a failed status of the nonlinear solver is more graceful and allows the code decide how best to handle things such as by cutting the time step.
These changes therefore change these fails to warns and modify the nonlinear solve to return a failed status from which application codes can more gracefully recover from.